### PR TITLE
Fix packaging files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     package_dir = {'': 'src'},
     include_package_data = True,
     package_data = {
-        '': ['README.rst',
+        'nose-machineout': ['README.rst',
              'requirements.txt',
              'requirements-test.txt'],
     },


### PR DESCRIPTION
Package fails to install from PyPi due to missing "requirements.txt"
Here's stacktrace from installation:

```
sudo pip install nose_machineout2
Collecting nose-machineout2
  Downloading nose_machineout2-0.5.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-_wockfop/nose-machineout2/setup.py", line 68, in <module>
        install_requires=readlist('requirements.txt'),
      File "/tmp/pip-build-_wockfop/nose-machineout2/setup.py", line 18, in readlist
        rows = read(filename).split("\n")
      File "/tmp/pip-build-_wockfop/nose-machineout2/setup.py", line 13, in read
        with open(filename, 'r') as fi:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-build-_wockfop/nose-machineout2/requirements.txt'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-_wockfop/nose-machineout2
```

And here are actual contents of PyPi package:

```
wget -O - https://pypi.python.org/packages/source/n/nose_machineout2/nose_machineout2-0.5.0.tar.gz#md5=7ad4dcd3212117e1903d9d8f2b4b935f | tar -zt                                                                                                                                                               
--2015-08-17 23:17:26--  https://pypi.python.org/packages/source/n/nose_machineout2/nose_machineout2-0.5.0.tar.gz
//omitted wget log

nose_machineout2-0.5.0/
nose_machineout2-0.5.0/PKG-INFO
nose_machineout2-0.5.0/README.rst
nose_machineout2-0.5.0/setup.cfg
nose_machineout2-0.5.0/setup.py
nose_machineout2-0.5.0/src/
nose_machineout2-0.5.0/src/nose_machineout/
nose_machineout2-0.5.0/src/nose_machineout/__init__.py
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/dependency_links.txt
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/entry_points.txt
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/PKG-INFO
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/SOURCES.txt
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/top_level.txt
nose_machineout2-0.5.0/src/nose_machineout2.egg-info/zip-safe
```

I think changing the package name in package_data will fix this issue.
